### PR TITLE
Add Starmetal ore recipe from emendatusenigmatica:iron_ore

### DIFF
--- a/kubejs/server_scripts/fixes.js
+++ b/kubejs/server_scripts/fixes.js
@@ -43,4 +43,24 @@ onEvent('recipes', event => {
 		})
 	})
 
+	event.custom({
+		'type': 'astralsorcery:block_transmutation',
+		'input': [
+		  {
+			'block': 'emendatusenigmatica:iron_ore',
+			'display': {
+			  'item': 'emendatusenigmatica:iron_ore',
+			  'count': 1
+			}
+		  }
+		],
+		'output': {
+		  'block': 'astralsorcery:starmetal_ore'
+		},
+		'display': {
+		  'item': 'astralsorcery:starmetal_ore',
+		  'count': 1
+		},
+		'starlight': 100.0
+	})
 })


### PR DESCRIPTION
It does not seems to work when using `#forge:ores/iron` in input `block` and `item`